### PR TITLE
Add emulation host element variant of SocketCANBridge

### DIFF
--- a/src/Emulator/Extensions/Tools/Network/CANHub.cs
+++ b/src/Emulator/Extensions/Tools/Network/CANHub.cs
@@ -120,8 +120,30 @@ namespace Antmicro.Renode.Tools.Network
                 }
                 foreach(var iface in attached.Where(x => (x != sender || loopback)))
                 {
-                    iface.GetMachine().HandleTimeDomainEvent(iface.OnFrameReceived, message, vts,
-                        frame != null ? () => FrameTransmitted?.Invoke(this, sender, iface, frame) : (Action)null);
+                    // When SocketCANBridge is created as a host machine element rather
+                    // than a machine peripheral, it has no machine context to use.
+                    // Which is expected.
+                    // Otherwise this supports the legacy machine peripheral variant.
+                    IMachine machine = null;
+                    if(iface is IHostMachineElement hostElement)
+                    {
+                        iface.TryGetMachine(out machine);
+                    }
+                    else
+                    {
+                        // Normal peripherals are required to have a machine context
+                        machine = iface.GetMachine();
+                    }
+
+                    if(machine == null)
+                    {
+                        iface.OnFrameReceived(message);
+                    }
+                    else
+                    {
+                        machine.HandleTimeDomainEvent(iface.OnFrameReceived, message, vts,
+                            frame != null ? () => FrameTransmitted?.Invoke(this, sender, iface, frame) : (Action)null);
+                    }
                 }
             }
         }

--- a/src/Emulator/Peripherals/Peripherals/CAN/SocketCANBridge.cs
+++ b/src/Emulator/Peripherals/Peripherals/CAN/SocketCANBridge.cs
@@ -28,9 +28,15 @@ namespace Antmicro.Renode.Peripherals.CAN
             machine.RegisterAsAChildOf(machine.SystemBus, bridge, NullRegistrationPoint.Instance);
             machine.SetLocalName(bridge, name);
         }
+
+        public static void CreateSocketCANBridge(this Emulation emulation, string name, string canInterfaceName = "vcan0", bool ensureFdFrames = false, bool ensureXlFrames = false)
+        {
+            var bridge = new SocketCANBridge(canInterfaceName, ensureFdFrames, ensureXlFrames);
+            emulation.HostMachine.AddHostMachineElement(bridge, name);
+        }
     }
 
-    public class SocketCANBridge : ICAN
+    public class SocketCANBridge : ICAN, IHostMachineElement, IDisposable
     {
         public SocketCANBridge(string canInterfaceName = "vcan0", bool ensureFdFrames = false, bool ensureXlFrames = false)
         {
@@ -71,6 +77,15 @@ namespace Antmicro.Renode.Peripherals.CAN
             StartTransmitThread();
         }
 
+        public void Dispose()
+        {
+            if(canSocket != -1)
+            {
+                LibCWrapper.Close(canSocket);
+                canSocket = -1;
+            }
+        }
+
         public void Reset()
         {
             // intentionally left empty
@@ -84,10 +99,9 @@ namespace Antmicro.Renode.Peripherals.CAN
             try
             {
                 // TODO for tx, I have to set useNetworkByteOrder=false
+                // I have no idea why this would be true?
                 // https://github.com/renode/renode/issues/641
-                frame = message.ToSocketCAN(false); 
-                //frame = message.ToSocketCAN(true);
-                // TODO why useNetworkByteOrder=true
+                frame = message.ToSocketCAN(false);
             }
             catch(RecoverableException e)
             {


### PR DESCRIPTION
Usage:
```
emulation CreateSocketCANBridge "socketcan" "vcan0" True False
connector Connect host.socketcan canhub
```

Previous machine-peripheral support is preserved.